### PR TITLE
Cp/graphql basics

### DIFF
--- a/cmd/transit/duboce.go
+++ b/cmd/transit/duboce.go
@@ -45,7 +45,30 @@ func display(infos []*consolidator.Info) {
 			if err != nil {
 				log.Println(err)
 			}
-			formattedTime := convertTime(t)
+			formattedTime := convertTime(t, false)
+			if stopInfo.Next == nil {
+				fmt.Printf("%s\n\n", formattedTime)
+			} else {
+				fmt.Printf("%s <- ", formattedTime)
+			}
+		}
+	}
+	specialDisplay := func(i *parser.ConciseStopInfo) {
+		special := false
+		if i != nil {
+			if i.StopName == "Carl St & Cole St" {
+				i.StopName = "Duboce St/Noe St/Duboce Park"
+				special = true
+			}
+			fmt.Printf("%s line (%s) train times for %s:\n", i.Line, i.Direction, i.StopName)
+		}
+
+		for stopInfo := i; stopInfo != nil; stopInfo = stopInfo.Next {
+			t, err := helpers.UTCtoPST(stopInfo.ExpectedTime)
+			if err != nil {
+				log.Println(err)
+			}
+			formattedTime := convertTime(t, special)
 			if stopInfo.Next == nil {
 				fmt.Printf("%s\n\n", formattedTime)
 			} else {
@@ -58,17 +81,15 @@ func display(infos []*consolidator.Info) {
 		inboundStopInfo := info.Direction.Inbound
 		outboundStopInfo := info.Direction.Outbound
 		// the only reason this is using a scoped function is because I felt like it
-		localDisplay(inboundStopInfo)
+		specialDisplay(inboundStopInfo)
 		localDisplay(outboundStopInfo)
 	}
 
 }
 
-func convertTime(t time.Time) string {
-	/*
-		if stopInfo.Direction == "IB" {
-			t = t.Add(TunnelTime)
-		}
-	*/
+func convertTime(t time.Time, specialCase bool) string {
+	if specialCase {
+		t = t.Add(TunnelTime)
+	}
 	return t.Format(time.Kitchen)
 }

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -2,25 +2,22 @@
 
 package model
 
-type Mickey struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+type Line struct {
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Stops []*Stop `json:"stops"`
 }
 
-type Mutation struct {
-}
-
-type NewTodo struct {
-	Text   string `json:"text"`
-	UserID string `json:"userId"`
+type Operator struct {
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Lines []*Line `json:"lines"`
 }
 
 type Query struct {
 }
 
-type Todo struct {
-	ID   string  `json:"id"`
-	Text string  `json:"text"`
-	Done bool    `json:"done"`
-	User *Mickey `json:"user"`
+type Stop struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -1,9 +1,14 @@
 package graph
 
+import "github.com/cpreciad/transit/graph/model"
+
 //go:generate go run github.com/99designs/gqlgen generate
 
 // This file will not be regenerated automatically.
 //
 // It serves as dependency injection for your app, add any dependencies you require here.
 
-type Resolver struct{}
+type Resolver struct {
+	stops []*model.Stop
+	//operators []*model.Operator
+}

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -2,27 +2,25 @@
 #
 # https://gqlgen.com/getting-started/
 
-type Todo {
-  id: ID!
-  text: String!
-  done: Boolean!
-  user: Mickey!
-}
-
-type Mickey {
+type Stop {
   id: ID!
   name: String!
 }
 
+type Line {
+  id: ID!
+  name: String!
+  stops: [Stop!]!
+}
+
+type Operator {
+  id: ID!
+  name: String!
+  lines: [Line!]!
+}
+
 type Query {
-  todos: [Todo!]!
-}
-
-input NewTodo {
-  text: String!
-  userId: String!
-}
-
-type Mutation {
-  createTodo(input: NewTodo!): Todo!
+  operators: [Operator!]!
+  operator(id: ID!): Operator
+  stopsForLine(operatorID: ID!, lineID: ID!): [Stop!]!
 }

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -9,23 +9,39 @@ import (
 	"fmt"
 
 	"github.com/cpreciad/transit/graph/model"
+	"github.com/cpreciad/transit/internal/consolidator"
 )
 
-// CreateTodo is the resolver for the createTodo field.
-func (r *mutationResolver) CreateTodo(ctx context.Context, input model.NewTodo) (*model.Todo, error) {
-	panic(fmt.Errorf("not implemented: CreateTodo - createTodo"))
+// Operators is the resolver for the operators field.
+func (r *queryResolver) Operators(ctx context.Context) ([]*model.Operator, error) {
+	panic(fmt.Errorf("not implemented: Operators - operators"))
 }
 
-// Todos is the resolver for the todos field.
-func (r *queryResolver) Todos(ctx context.Context) ([]*model.Todo, error) {
-	panic(fmt.Errorf("not implemented: Todos - todos"))
+// Operator is the resolver for the operator field.
+func (r *queryResolver) Operator(ctx context.Context, id string) (*model.Operator, error) {
+	panic(fmt.Errorf("not implemented: Operator - operator"))
 }
 
-// Mutation returns MutationResolver implementation.
-func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
+// StopsForLine is the resolver for the stopsForLine field.
+func (r *queryResolver) StopsForLine(ctx context.Context, operatorID string, lineID string) ([]*model.Stop, error) {
+	stops := make(map[string][]string)
+	stops["Carl St & Cole St"] = make([]string, 0)
+	stops["Duboce St/Noe St/Duboce Park"] = make([]string, 0)
+	stopInfo := consolidator.GetStopInfo(operatorID, lineID, stops)
+
+	// construct the return for the stops
+	for _, stop := range stopInfo {
+		formattedStop := &model.Stop{
+			ID:   "1",
+			Name: stop.Direction.Outbound.StopName,
+		}
+		r.stops = append(r.stops, formattedStop)
+	}
+	return r.stops, nil
+
+}
 
 // Query returns QueryResolver implementation.
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
-type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }

--- a/internal/consolidator/consolidator.go
+++ b/internal/consolidator/consolidator.go
@@ -101,7 +101,7 @@ func handleBackup(fileName string, body []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		log.Println("consolidator: backup data for %s loaded successfully", fileName)
+		log.Printf("consolidator: backup data for %s loaded successfully\n", fileName)
 		body = backup
 	}
 	return body, nil


### PR DESCRIPTION
adds the basics of a gql query. It will need to be fleshed out more as far as not passing in hard coded values, it needs a way to pull the stop names and associate them with a stop ID, and it will need a way to just query all of the stops if nothing is passed into the consolidator


the consolidator might need to be refactored, and it might need to format the data to be a bit more friendly. But this will do for now at least for getting gql to actually work 