### PR TITLE
Cp/implement line queries

### DIFF
--- a/cmd/transit/api/api_qe_validate.go
+++ b/cmd/transit/api/api_qe_validate.go
@@ -10,9 +10,22 @@ import (
 // this is just to test the api query engine implementation
 func main() {
 	apiqe := apiqe.NewApiQueryEngine()
-	out, err := apiqe.GetOperatorID()
+	outO, err := apiqe.GetOperatorID()
+
 	if err != nil {
 		slog.Error("ez error", "returned error:", err.Error())
 	}
-	fmt.Println(out)
+	fmt.Println(outO)
+
+	for _, v := range outO {
+		l, err := apiqe.GetLineID(v.OperatorID)
+		if err != nil {
+			slog.Error("ez error", "returned error:", err.Error())
+		}
+		fmt.Println(v.OperatorID)
+		fmt.Println(l)
+		fmt.Println("----")
+
+	}
+
 }

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -131,7 +131,7 @@ models:
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
       - github.com/99designs/gqlgen/graphql.Int32
-  # gqlgen provides a default GraphQL UUID convenience wrapper for github.com/google/uuid 
+  # gqlgen provides a default GraphQL UUID convenience wrapper for github.com/google/uuid
   # but you can override this to provide your own GraphQL UUID implementation
   UUID:
     model:
@@ -153,3 +153,7 @@ models:
     model:
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
+  Operator:
+    fields:
+      lines:
+        resolver: true

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -61,9 +61,8 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Operator     func(childComplexity int, id string) int
-		Operators    func(childComplexity int, order *model.SortOrder) int
-		StopsForLine func(childComplexity int, operatorID string, lineID string) int
+		Operator  func(childComplexity int, id string) int
+		Operators func(childComplexity int, order *model.SortOrder) int
 	}
 
 	Stop struct {
@@ -76,7 +75,6 @@ type ComplexityRoot struct {
 type QueryResolver interface {
 	Operators(ctx context.Context, order *model.SortOrder) ([]*model.Operator, error)
 	Operator(ctx context.Context, id string) (*model.Operator, error)
-	StopsForLine(ctx context.Context, operatorID string, lineID string) ([]*model.Stop, error)
 }
 
 type executableSchema struct {
@@ -177,18 +175,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Operators(childComplexity, args["order"].(*model.SortOrder)), true
-
-	case "Query.stopsForLine":
-		if e.complexity.Query.StopsForLine == nil {
-			break
-		}
-
-		args, err := ec.field_Query_stopsForLine_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.StopsForLine(childComplexity, args["operatorID"].(string), args["lineID"].(string)), true
 
 	case "Stop.id":
 		if e.complexity.Stop.ID == nil {
@@ -385,47 +371,6 @@ func (ec *executionContext) field_Query_operators_argsOrder(
 	}
 
 	var zeroVal *model.SortOrder
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_stopsForLine_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := ec.field_Query_stopsForLine_argsOperatorID(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["operatorID"] = arg0
-	arg1, err := ec.field_Query_stopsForLine_argsLineID(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["lineID"] = arg1
-	return args, nil
-}
-func (ec *executionContext) field_Query_stopsForLine_argsOperatorID(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (string, error) {
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("operatorID"))
-	if tmp, ok := rawArgs["operatorID"]; ok {
-		return ec.unmarshalNID2string(ctx, tmp)
-	}
-
-	var zeroVal string
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_stopsForLine_argsLineID(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (string, error) {
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("lineID"))
-	if tmp, ok := rawArgs["lineID"]; ok {
-		return ec.unmarshalNID2string(ctx, tmp)
-	}
-
-	var zeroVal string
 	return zeroVal, nil
 }
 
@@ -1020,69 +965,6 @@ func (ec *executionContext) fieldContext_Query_operator(ctx context.Context, fie
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_operator_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_stopsForLine(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_stopsForLine(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().StopsForLine(rctx, fc.Args["operatorID"].(string), fc.Args["lineID"].(string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]*model.Stop)
-	fc.Result = res
-	return ec.marshalNStop2ᚕᚖgithubᚗcomᚋcpreciadᚋtransitᚋgraphᚋmodelᚐStopᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_stopsForLine(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Stop_id(ctx, field)
-			case "stopId":
-				return ec.fieldContext_Stop_stopId(ctx, field)
-			case "name":
-				return ec.fieldContext_Stop_name(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_stopsForLine_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -3470,28 +3352,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_operator(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "stopsForLine":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_stopsForLine(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
 				return res
 			}
 

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -13,6 +13,5 @@ import (
 
 type Resolver struct {
 	QueryEngine queryengine.QueryEngine
-	stops       []*model.Stop
 	operators   []*model.Operator
 }

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -14,4 +14,5 @@ import (
 type Resolver struct {
 	QueryEngine queryengine.QueryEngine
 	operators   []*model.Operator
+	lines       []*model.Line
 }

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -30,5 +30,4 @@ enum SortOrder {
 type Query {
   operators(order: SortOrder = ASC): [Operator!]!
   operator(id: ID!): Operator
-  stopsForLine(operatorID: ID!, lineID: ID!): [Stop!]!
 }

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/cpreciad/transit/cmd/transit/duboce/consolidator"
 	"github.com/cpreciad/transit/graph/model"
 	qe "github.com/cpreciad/transit/query_engine"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -76,24 +75,6 @@ func (r *queryResolver) Operator(ctx context.Context, id string) (*model.Operato
 		Name:       operator.Name,
 		Lines:      nil, // TODO: implement recursive calls to Lines
 	}, nil
-}
-
-// StopsForLine is the resolver for the stopsForLine field.
-func (r *queryResolver) StopsForLine(ctx context.Context, operatorID string, lineID string) ([]*model.Stop, error) {
-	stops := make(map[string][]string)
-	stops["Carl St & Cole St"] = make([]string, 0)
-	stops["Duboce St/Noe St/Duboce Park"] = make([]string, 0)
-	stopInfo := consolidator.GetStopInfo(operatorID, lineID, stops)
-
-	// construct the return for the stops
-	for _, stop := range stopInfo {
-		formattedStop := &model.Stop{
-			ID:   "1",
-			Name: stop.Direction.Outbound.StopName,
-		}
-		r.stops = append(r.stops, formattedStop)
-	}
-	return r.stops, nil
 }
 
 // Query returns QueryResolver implementation.

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -6,6 +6,7 @@ package graph
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sort"
 	"strconv"
@@ -78,19 +79,20 @@ func (r *queryResolver) Operator(ctx context.Context, id string) (*model.Operato
 // Lines is the resolver for the lines field.
 func (r *operatorResolver) Lines(ctx context.Context, obj *model.Operator) ([]*model.Line, error) {
 	lines, err := r.QueryEngine.GetLineID(obj.OperatorID)
+	var l []*model.Line
 	if err != nil {
 		slog.Error("QueryResolver", "Method", "Line", "Error", err.Error())
 		return nil, gqlerror.Errorf("Internal server error occurred")
 	}
 	for lID, line := range lines {
-		op := lines[lID]
-		slog.Info("line info: ", "id", string(lID), "lID", line.LineID, "name", op.Name)
-		r.lines = append(r.lines, &model.Line{
+		l = append(l, &model.Line{
 			ID:     string(lID),
 			LineID: line.LineID,
 			Name:   line.Name,
 		})
 	}
+	r.lines = l
+	fmt.Printf("size of r.lines for operator id: %s: %d\n", obj.OperatorID, len(r.lines))
 	return r.lines, nil
 }
 

--- a/internal/api_query_engine/api_query_engine.go
+++ b/internal/api_query_engine/api_query_engine.go
@@ -26,8 +26,18 @@ func (a *apiQueryEngine) GetOperatorID() (map[qe.ID]qe.Operator, error) {
 	return out, nil
 }
 
-func (a *apiQueryEngine) GetLineID(oid qe.ID) (map[qe.ID]qe.Line, error) {
-	return nil, nil
+func (a *apiQueryEngine) GetLineID(oid string) (map[qe.ID]qe.Line, error) {
+	// make the fetch function generic
+	fetch := func() ([]byte, error) {
+		return lineFetch(oid)
+	}
+
+	out, err := fetchAndFormatData(fetch, lineFormat, lineValidate)
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
 }
 
 func fetchAndFormatData[K comparable, V qe.Operator | qe.Line](fetch func() ([]byte, error), format func([]byte) (map[K]V, error), validate func(map[K]V) error) (map[K]V, error) {

--- a/internal/api_query_engine/api_query_engine.go
+++ b/internal/api_query_engine/api_query_engine.go
@@ -1,6 +1,9 @@
 package apiqe
 
 import (
+	"fmt"
+	"os"
+
 	qe "github.com/cpreciad/transit/query_engine"
 )
 
@@ -8,16 +11,24 @@ const (
 	apiKeyEnv = "TRANSIT_DATA_API_KEY"
 )
 
-type apiQueryEngine struct{}
-
-func NewApiQueryEngine() *apiQueryEngine {
-	return &apiQueryEngine{}
+type apiQueryEngine struct {
+	apiKey string
 }
 
-// TODO: figure out how to make factory functions for each transit type
+func NewApiQueryEngine() *apiQueryEngine {
+	apiKey := os.Getenv(apiKeyEnv)
+	if apiKey == "" {
+		panicMessage := fmt.Sprintf("NewApiQueryEngine: an api key is not mapped to the env variable %s. Please go to 511.org, register for an api key, and set it to the listed env variable", apiKeyEnv)
+		panic(panicMessage)
+	}
+	return &apiQueryEngine{
+		apiKey: apiKey,
+	}
+}
+
 func (a *apiQueryEngine) GetOperatorID() (map[qe.ID]qe.Operator, error) {
 
-	out, err := fetchAndFormatData(operatorFetch, operatorFormat, operatorValidate)
+	out, err := fetchAndFormatData(operatorFetch, operatorFormat, operatorValidate, a.apiKey)
 
 	if err != nil {
 		return nil, err
@@ -28,11 +39,11 @@ func (a *apiQueryEngine) GetOperatorID() (map[qe.ID]qe.Operator, error) {
 
 func (a *apiQueryEngine) GetLineID(oid string) (map[qe.ID]qe.Line, error) {
 	// make the fetch function generic
-	fetch := func() ([]byte, error) {
-		return lineFetch(oid)
+	fetch := func(string) ([]byte, error) {
+		return lineFetch(a.apiKey, oid)
 	}
 
-	out, err := fetchAndFormatData(fetch, lineFormat, lineValidate)
+	out, err := fetchAndFormatData(fetch, lineFormat, lineValidate, a.apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -40,10 +51,10 @@ func (a *apiQueryEngine) GetLineID(oid string) (map[qe.ID]qe.Line, error) {
 	return out, nil
 }
 
-func fetchAndFormatData[K comparable, V qe.Operator | qe.Line](fetch func() ([]byte, error), format func([]byte) (map[K]V, error), validate func(map[K]V) error) (map[K]V, error) {
+func fetchAndFormatData[K comparable, V qe.Operator | qe.Line](fetch func(string) ([]byte, error), format func([]byte) (map[K]V, error), validate func(map[K]V) error, apiKey string) (map[K]V, error) {
 
 	// get the body of the request to the 511 API
-	body, err := fetch()
+	body, err := fetch(apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -60,9 +71,4 @@ func fetchAndFormatData[K comparable, V qe.Operator | qe.Line](fetch func() ([]b
 	}
 
 	return out, nil
-}
-
-// TODO: find a way to validate the unpacking after a successful unmarshal
-func validate([]Operator) error {
-	return nil
 }

--- a/internal/api_query_engine/lines.go
+++ b/internal/api_query_engine/lines.go
@@ -1,13 +1,79 @@
 package apiqe
 
-import qe "github.com/cpreciad/transit/query_engine"
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
 
-func lineFetch(oid string) ([]byte, error) {
-	return nil, nil
+	"github.com/cpreciad/transit/internal/helpers"
+	qe "github.com/cpreciad/transit/query_engine"
+)
+
+const (
+	linesUrl = "http://api.511.org/transit/lines"
+)
+
+type Line struct {
+	LineID string `json:"Id"`
+	Name   string `json:"Name"`
+}
+
+func lineFetch(apiKey, oid string) ([]byte, error) {
+	url := fmt.Sprintf("%s?api_key=%s&operator_id=%s&format=json", linesUrl, apiKey, oid)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("lineFetch: bad status code returned: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("lineFetch: %s", err.Error())
+	}
+	body = helpers.CleanResponseBody(body)
+	resp.Body.Close()
+
+	return body, nil
+
 }
 func lineFormat(data []byte) (map[qe.ID]qe.Line, error) {
-	return nil, nil
+	var unpackedLines []Line
+	if err := json.Unmarshal(data, &unpackedLines); err != nil {
+		return nil, fmt.Errorf("lineFormat: %w", err)
+	}
+
+	m := make(map[qe.ID]qe.Line)
+	for i, l := range unpackedLines {
+		// getting in the habit of using database ids, as this data will eventually be stored there
+		id := qe.ID(strconv.Itoa(i + 1))
+		m[id] = qe.Line{
+			ID:     string(id),
+			LineID: l.LineID,
+			Name:   l.Name,
+		}
+	}
+
+	return m, nil
 }
 func lineValidate(map[qe.ID]qe.Line) error {
 	return nil
 }
+
+// A SAMPLE OF WHAT THE DATA LOOKS LIKE
+// values can either be strings or null, likely transposing to the empty string ""
+/*
+{"Id":"49",
+"Name":"VAN NESS-MISSION",
+"FromDate":"2025-06-21T00:00:00-07:00",
+"ToDate":"2025-08-29T23:59:00-07:00",
+"TransportMode":"bus",
+"PublicCode":"49",
+"SiriLineRef":"49",
+"Monitored":true,
+"OperatorRef":"SF"}
+*/

--- a/internal/api_query_engine/lines.go
+++ b/internal/api_query_engine/lines.go
@@ -1,0 +1,13 @@
+package apiqe
+
+import qe "github.com/cpreciad/transit/query_engine"
+
+func lineFetch(oid string) ([]byte, error) {
+	return nil, nil
+}
+func lineFormat(data []byte) (map[qe.ID]qe.Line, error) {
+	return nil, nil
+}
+func lineValidate(map[qe.ID]qe.Line) error {
+	return nil
+}

--- a/internal/api_query_engine/operators.go
+++ b/internal/api_query_engine/operators.go
@@ -15,28 +15,27 @@ const (
 	operatorsUrl = "http://api.511.org/transit/operators"
 )
 
+// these struct fields need to be exported so the json lib sees them, idk
 type Operator struct {
 	OperatorID string `json:"Id"`
 	Name       string `json:"Name"`
 }
 
-func operatorFetch() ([]byte, error) {
-	url, err := helpers.ConstructUrl(apiKeyEnv, operatorsUrl)
-	if err != nil {
-		return nil, err
-	}
+func operatorFetch(apiKey string) ([]byte, error) {
+
+	url := fmt.Sprintf("%s?api_key=%s&format=json", operatorsUrl, apiKey)
 
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("fetchData: bad status code returned: %d", resp.StatusCode)
+		return nil, fmt.Errorf("operatorFetch: bad status code returned: %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("fetchData: %s", err.Error())
+		return nil, fmt.Errorf("operatorFetch: %s", err.Error())
 	}
 	body = helpers.CleanResponseBody(body)
 	resp.Body.Close()
@@ -47,10 +46,6 @@ func operatorFetch() ([]byte, error) {
 func operatorFormat(data []byte) (map[qe.ID]qe.Operator, error) {
 	var unpackedOperators []Operator
 	if err := json.Unmarshal(data, &unpackedOperators); err != nil {
-		return nil, fmt.Errorf("formatApiData: %w", err)
-	}
-
-	if err := validate(unpackedOperators); err != nil {
 		return nil, fmt.Errorf("formatApiData: %w", err)
 	}
 

--- a/query_engine/query_engine.go
+++ b/query_engine/query_engine.go
@@ -11,7 +11,8 @@ type ID string
 
 type QueryEngine interface {
 	GetOperatorID() (map[ID]Operator, error)
-	GetLineID(oid ID) (map[ID]Line, error)
+	// TODO: make oid more type specific
+	GetLineID(oid string) (map[ID]Line, error)
 	// GetStopID(oid, lid string)
 	// GetStopMonintor(sid string)
 }


### PR DESCRIPTION
This pr adds line queries to the mix, so it introduces a new lines struct for the query engine, and follows the format of the operator structure, with the fetch and functions unique to it

one paradigm that will follow will be discussing the fetch function to be a "single string parameterized function" because I want to keep the fetchAndFormat function generic, and its just kinda cool that you can disguise functions like this in go

there is a bit of refactoring I did as well

1. update the NewApiQueryEngine function to load the apikey into memory for the object when its created upon initialization, because its just easier if it can be easily called by each struct specific function
2. change the fetch and format generic function signature to take into account the api key