### PR TITLE
Cp/cache lines

### DIFF
--- a/cmd/transit/api/api_qe_validate.go
+++ b/cmd/transit/api/api_qe_validate.go
@@ -3,14 +3,22 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"os"
 
 	apiqe "github.com/cpreciad/transit/internal/api_query_engine"
 )
 
+const apiKeyEnv = "TRANSIT_DATA_API_KEY"
+
 // this is just to test the api query engine implementation
 func main() {
-	apiqe := apiqe.NewApiQueryEngine()
-	outO, err := apiqe.GetOperatorID()
+	apiKey := os.Getenv(apiKeyEnv)
+	if apiKey == "" {
+		panicMessage := fmt.Sprintf("NewApiQueryEngine: an api key is not mapped to the env variable %s. Please go to 511.org, register for an api key, and set it to the listed env variable", apiKeyEnv)
+		panic(panicMessage)
+	}
+	api := apiqe.NewApiQueryEngine(apiKey)
+	outO, err := api.GetOperatorID()
 
 	if err != nil {
 		slog.Error("ez error", "returned error:", err.Error())
@@ -18,7 +26,7 @@ func main() {
 	fmt.Println(outO)
 
 	for _, v := range outO {
-		l, err := apiqe.GetLineID(v.OperatorID)
+		l, err := api.GetLineID(v.OperatorID)
 		if err != nil {
 			slog.Error("ez error", "returned error:", err.Error())
 		}

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -12,7 +12,7 @@ import (
 // It serves as dependency injection for your app, add any dependencies you require here.
 
 type Resolver struct {
-	QueryEngine queryengine.QueryEngine
+	queryEngine queryengine.QueryEngine
 	// TODO: update these to store data more efficiently
 	// these don't need to be updated nearly as often, so
 	// a data structure that allows quicker loading will be better
@@ -20,4 +20,11 @@ type Resolver struct {
 	operators []*model.Operator
 	// map[id][]*model.Line
 	lines map[string][]*model.Line
+}
+
+func NewResolver(qe queryengine.QueryEngine) *Resolver {
+	return &Resolver{
+		queryEngine: qe,
+		lines:       make(map[string][]*model.Line),
+	}
 }

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -13,6 +13,11 @@ import (
 
 type Resolver struct {
 	QueryEngine queryengine.QueryEngine
-	operators   []*model.Operator
-	lines       []*model.Line
+	// TODO: update these to store data more efficiently
+	// these don't need to be updated nearly as often, so
+	// a data structure that allows quicker loading will be better
+	// map[id][]*model.Operator
+	operators []*model.Operator
+	// map[id][]*model.Line
+	lines map[string][]*model.Line
 }

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -78,6 +78,9 @@ func (r *queryResolver) Operator(ctx context.Context, id string) (*model.Operato
 
 // Lines is the resolver for the lines field.
 func (r *operatorResolver) Lines(ctx context.Context, obj *model.Operator) ([]*model.Line, error) {
+	if lines, ok := r.lines[obj.OperatorID]; ok {
+		return lines, nil
+	}
 	lines, err := r.QueryEngine.GetLineID(obj.OperatorID)
 	var l []*model.Line
 	if err != nil {
@@ -91,9 +94,9 @@ func (r *operatorResolver) Lines(ctx context.Context, obj *model.Operator) ([]*m
 			Name:   line.Name,
 		})
 	}
-	r.lines = l
+	r.lines[obj.OperatorID] = l
 	fmt.Printf("size of r.lines for operator id: %s: %d\n", obj.OperatorID, len(r.lines))
-	return r.lines, nil
+	return r.lines[obj.OperatorID], nil
 }
 
 // Operator returns OperatorResolver implementation.

--- a/internal/api_query_engine/api_query_engine.go
+++ b/internal/api_query_engine/api_query_engine.go
@@ -1,26 +1,14 @@
 package apiqe
 
 import (
-	"fmt"
-	"os"
-
 	qe "github.com/cpreciad/transit/query_engine"
-)
-
-const (
-	apiKeyEnv = "TRANSIT_DATA_API_KEY"
 )
 
 type apiQueryEngine struct {
 	apiKey string
 }
 
-func NewApiQueryEngine() *apiQueryEngine {
-	apiKey := os.Getenv(apiKeyEnv)
-	if apiKey == "" {
-		panicMessage := fmt.Sprintf("NewApiQueryEngine: an api key is not mapped to the env variable %s. Please go to 511.org, register for an api key, and set it to the listed env variable", apiKeyEnv)
-		panic(panicMessage)
-	}
+func NewApiQueryEngine(apiKey string) *apiQueryEngine {
 	return &apiQueryEngine{
 		apiKey: apiKey,
 	}

--- a/query_engine/query_engine.go
+++ b/query_engine/query_engine.go
@@ -9,11 +9,13 @@ package queryengine
 // they're doing, or something like that
 type ID string
 
+// TODO: Make a decision on how to better ensure type safety
+
 type QueryEngine interface {
 	GetOperatorID() (map[ID]Operator, error)
 	// TODO: make oid more type specific
 	GetLineID(oid string) (map[ID]Line, error)
-	// GetStopID(oid, lid string)
+	// GetStopID(oid, lid string) (map[ID]Stop, error)
 	// GetStopMonintor(sid string)
 }
 
@@ -33,3 +35,11 @@ type Line struct {
 	LineID string `json:"lineid"`
 	Name   string `json:"name"`
 }
+
+/*
+type Stop struct {
+	ID     string `json:"id"`
+	LineID string `json:"stopid"`
+	Name   string `json:"name"`
+}
+*/

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -15,7 +16,10 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-const defaultPort = "8080"
+const (
+	defaultPort = "8080"
+	apiKeyEnv   = "TRANSIT_DATA_API_KEY"
+)
 
 func main() {
 	port := os.Getenv("PORT")
@@ -23,11 +27,17 @@ func main() {
 		port = defaultPort
 	}
 
+	apiKey := os.Getenv(apiKeyEnv)
+	if apiKey == "" {
+		panicMessage := fmt.Sprintf("NewApiQueryEngine: an api key is not mapped to the env variable %s. Please go to 511.org, register for an api key, and set it to the listed env variable", apiKeyEnv)
+		panic(panicMessage)
+	}
+
 	// this should be where a resolver type should be injected
 
-	srv := handler.New(graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{
-		QueryEngine: apiqe.NewApiQueryEngine(),
-	}}))
+	srv := handler.New(graph.NewExecutableSchema(graph.Config{
+		Resolvers: graph.NewResolver(apiqe.NewApiQueryEngine(apiKey)),
+	}))
 
 	srv.AddTransport(transport.Options{})
 	srv.AddTransport(transport.GET{})


### PR DESCRIPTION
This PR adds some caching to the lines resolver via map, where the key is the operator ID.

I should probably start widely using the actual ID for the caching, but I'm just not sure about the long term implications of that. Maybe I can keep the actual ID for queries of individual objects, such as line/operator queries. 🤷 

anyways, I also refactor the creation of the resolver so that the lines map can be created, as well as the api key instantiation. simple stuffs